### PR TITLE
Add redux-devtools-extension support

### DIFF
--- a/cancerbrowser/common/utils/configureStore.js
+++ b/cancerbrowser/common/utils/configureStore.js
@@ -11,7 +11,7 @@ export default function configureStore(initialState = undefined) {
       applyMiddleware(
         thunkMiddleware // lets us dispatch() functions
       ),
-      (window.__DEVELOPMENT__ && window.devToolsExtension) ? window.devToolsExtension() : f => f
+      (window.devToolsExtension) ? window.devToolsExtension() : f => f
     )
   );
   return store;

--- a/cancerbrowser/webpack.config.js
+++ b/cancerbrowser/webpack.config.js
@@ -25,8 +25,7 @@ module.exports = [
       }),
       new CopyWebpackPlugin([
         { from: 'data', to: 'data' }
-      ]),
-      new webpack.DefinePlugin({'window.__DEVELOPMENT__': true})
+      ])
     ],
     devtool: 'source-map',
     entry: {
@@ -90,8 +89,7 @@ module.exports = [
       new ExtractTextPlugin('styles.css'),
       new CopyWebpackPlugin([
         { from: 'data', to: 'data' }
-      ]),
-      new webpack.DefinePlugin({'window.__DEVELOPMENT__': true})
+      ])
     ],
     entry: ['./server/server.jsx'],
     target: 'node',


### PR DESCRIPTION
Adds support for:

https://github.com/zalmoxisus/redux-devtools-extension

Once the chrome extension is installed, it looks like we can inspect the state and lots more!

<img width="436" alt="screen shot 2016-05-26 at 8 37 58 am" src="https://cloud.githubusercontent.com/assets/9369/15580479/c08c9040-231d-11e6-95b4-c8308b7871a3.png">
