### PR TITLE
Generate counts of matched filters in API

### DIFF
--- a/cancerbrowser/common/actions/cell_line.js
+++ b/cancerbrowser/common/actions/cell_line.js
@@ -2,6 +2,7 @@ import api from '../api';
 
 export const SET_FILTERED_CELL_LINES = 'SET_FILTERED_CELL_LINES';
 export const CHANGE_CELL_LINE_VIEW = 'CHANGE_CELL_LINE_VIEW';
+export const SET_CELL_LINE_COUNTS = 'SET_CELL_LINE_COUNTS';
 
 /**
  * Action creator for setting filtered cell lines
@@ -10,6 +11,16 @@ function setFilteredCellLines(cellLines) {
   return {
     type: SET_FILTERED_CELL_LINES,
     cellLines: cellLines
+  };
+}
+
+/**
+ * Action creator for setting filtered cell lines
+ */
+function setCellLineCounts(counts) {
+  return {
+    type: SET_CELL_LINE_COUNTS,
+    counts: counts
   };
 }
 
@@ -27,11 +38,16 @@ function shouldFetchCellLines(state) {
  * Helper function to get cellines given a set of filterGroups
  * @return {Function}
  */
-function fetchCellLines(filterGroups) {
+function fetchCellLines(filterGroups, allFilterGroups) {
   return dispatch => {
-    api.getCellLines(filterGroups).then(
-      json => dispatch(setFilteredCellLines(json))
-    );
+    api.getCellLines(filterGroups)
+    .then((data) => {
+      dispatch(setFilteredCellLines(data));
+      return data;
+    })
+    //TODO: should this be split into 2 different action creators?
+    .then(data => api.getCellLineCounts(data, allFilterGroups))
+    .then(counts => dispatch(setCellLineCounts(counts)));
   };
 }
 
@@ -39,10 +55,10 @@ function fetchCellLines(filterGroups) {
  * Public function to acquire cell line data
  * and create action to store it.
  */
-export function fetchCellLinesIfNeeded(filterGroups) {
+export function fetchCellLinesIfNeeded(activeFilterGroups, allFilterGroups) {
   return (dispatch, getState) => {
     if (shouldFetchCellLines(getState())) {
-      return dispatch(fetchCellLines(filterGroups));
+      return dispatch(fetchCellLines(activeFilterGroups, allFilterGroups));
     }
   };
 }

--- a/cancerbrowser/common/api/cell_line.js
+++ b/cancerbrowser/common/api/cell_line.js
@@ -1,11 +1,18 @@
 
-import { filterData } from './util';
+import { filterData, countMatchedFilterGroups } from './util';
 
 import _ from 'lodash';
 
 //TODO async load cell line data.
 import cellLinesData from  './data/cell_lines.json';
 
+/**
+ * Returns filtered cell line data given a set of filters
+ *
+ * @param {Object} filterGroups object with keys as each id
+ *  of the filter group. Values are objects passed to filterData
+ * @return {Array} filtered set of cell line data
+ */
 export function getCellLines(filterGroups = {}) {
   return new Promise(function(resolve) {
 
@@ -17,4 +24,15 @@ export function getCellLines(filterGroups = {}) {
     resolve(filteredCellLines);
   });
 
+}
+
+/**
+ * Provides counts for each filter group in the allFilterGroup
+ *
+ * @param {Array} cellLines array of cell line data to match
+ * @param {Object} filter groups for the cell line data.
+ *
+ */
+export function getCellLineCounts(cellLines, allFilterGroups) {
+  return countMatchedFilterGroups(cellLines, allFilterGroups);
 }

--- a/cancerbrowser/common/api/index.js
+++ b/cancerbrowser/common/api/index.js
@@ -1,10 +1,11 @@
 
-import { getCellLines } from './cell_line';
+import { getCellLines, getCellLineCounts } from './cell_line';
 import { getDataset, getDatasets, getDatasetInfo } from './dataset';
 
 export default {
-  getDatasets: getDatasets,
-  getDatasetInfo: getDatasetInfo,
-  getCellLines: getCellLines,
-  getDataset: getDataset
+  getDatasets,
+  getDatasetInfo,
+  getDataset,
+  getCellLines,
+  getCellLineCounts
 };

--- a/cancerbrowser/common/api/util.js
+++ b/cancerbrowser/common/api/util.js
@@ -66,3 +66,41 @@ function getCategoricalMatches(row, filterGroup) {
 
   return matches;
 }
+
+/**
+ * Provides counts for each filter group in the allFilterGroup
+ *
+ * @param {Array} data array of data to match to
+ * @param {Object} filter groups for the cell line data.
+ *
+ */
+export function countMatchedFilterGroups(data, allFilterGroups) {
+  var allCounts = {};
+  Object.keys(allFilterGroups).forEach(function(key) {
+    var filterGroup = allFilterGroups[key];
+    var filterGroupCounts = {};
+    filterGroup.filters.forEach(function(filter) {
+      filterGroupCounts[filter.id] = {};
+      filterGroupCounts[filter.id]['counts'] = countMatchedFilterData(data, filter);
+
+    });
+    allCounts[filterGroup.id] = filterGroupCounts;
+  });
+
+  return allCounts;
+}
+
+/**
+ * Provides counts for how many values match
+ *
+ */
+function countMatchedFilterData(data, filter) {
+  var filterCounts = {};
+  filter.values.forEach(function(value) {
+    var fakeFilterGroup = [{id:filter.id, values:value.value}];
+    var results = filterData(data, fakeFilterGroup);
+    filterCounts[value.value] = results.length;
+  });
+
+  return filterCounts;
+}

--- a/cancerbrowser/common/containers/CellLineBrowserPage/index.jsx
+++ b/cancerbrowser/common/containers/CellLineBrowserPage/index.jsx
@@ -20,14 +20,16 @@ const propTypes = {
   params: React.PropTypes.object,
   filteredCellLines: React.PropTypes.array,
   activeFilters: React.PropTypes.object,
-  cellLineView: React.PropTypes.string
+  cellLineView: React.PropTypes.string,
+  cellLineCounts: React.PropTypes.object
 };
 
 function mapStateToProps(state) {
   return {
     cellLineView: state.cellLines.cellLineView,
     filteredCellLines: state.cellLines.filtered,
-    activeFilters: state.filters.active
+    activeFilters: state.filters.active,
+    cellLineCounts: state.cellLines.counts
   };
 }
 
@@ -124,12 +126,12 @@ class CellLineBrowserPage extends React.Component {
   }
 
   componentDidMount() {
-    this.props.dispatch(fetchCellLinesIfNeeded());
+    this.props.dispatch(fetchCellLinesIfNeeded({}, filterGroups));
   }
 
   onFilterChange(newFilters) {
     this.props.dispatch(changeActiveFilters(newFilters));
-    this.props.dispatch(fetchCellLinesIfNeeded(newFilters));
+    this.props.dispatch(fetchCellLinesIfNeeded(newFilters, filterGroups));
   }
 
   onCellLineFilterChange(newCellLineFilters) {
@@ -137,7 +139,7 @@ class CellLineBrowserPage extends React.Component {
     const newActiveFilters = Object.assign({}, activeFilters, { cellLineFilters: newCellLineFilters });
 
     this.props.dispatch(changeActiveFilters(newActiveFilters));
-    this.props.dispatch(fetchCellLinesIfNeeded(newActiveFilters));
+    this.props.dispatch(fetchCellLinesIfNeeded(newActiveFilters, filterGroups));
   }
 
   onCellLineViewChange(evt) {
@@ -145,25 +147,17 @@ class CellLineBrowserPage extends React.Component {
     this.props.dispatch(changeCellLineView(newView));
   }
 
+  /**
+   * Renders the cell line filter side bar
+   *
+   * @return {React.Component}
+   */
   renderSidebar() {
-    // TODO: this needs to come from an API
-    const counts = {
-      cellLineFilters: {
-        collection: {
-          counts: {
-            big6: 6,
-            icbp43: 43
-          },
-          countMax: 43
-        }
-      }
-    };
-
     return (
       <FilterPanel
         filterGroups={filterGroups}
         activeFilters={this.props.activeFilters}
-        counts={counts}
+        counts={this.props.cellLineCounts}
         onFilterChange={this.onFilterChange} />
     );
   }

--- a/cancerbrowser/common/reducers/cell_lines.js
+++ b/cancerbrowser/common/reducers/cell_lines.js
@@ -1,9 +1,10 @@
 
-import { SET_FILTERED_CELL_LINES, CHANGE_CELL_LINE_VIEW } from '../actions/cell_line';
+import { SET_FILTERED_CELL_LINES, CHANGE_CELL_LINE_VIEW, SET_CELL_LINE_COUNTS } from '../actions/cell_line';
 
 const INITIAL_STATE = {
   filtered: [],
-  isFetching: false
+  isFetching: false,
+  counts: {}
 };
 
 function cellLines(state = INITIAL_STATE, action) {
@@ -17,6 +18,11 @@ function cellLines(state = INITIAL_STATE, action) {
     case CHANGE_CELL_LINE_VIEW:
       return Object.assign({}, state, {
         cellLineView: action.cellLineView
+      });
+
+    case SET_CELL_LINE_COUNTS:
+      return Object.assign({}, state, {
+        counts: action.counts
       });
 
     default:


### PR DESCRIPTION
Adds count generation to the get filtered cell line
action creation.

Uses this data in the cell line browser to populate 
counts.
