### PR TITLE
Set default page size to 100 for Cell Line Table

### DIFF
--- a/cancerbrowser/common/components/CellLineTable/index.jsx
+++ b/cancerbrowser/common/components/CellLineTable/index.jsx
@@ -189,7 +189,7 @@ class CellLineTable extends React.Component {
         keys={keys}
         columns={columnSet}
         initialData={data}
-        initialPageLength={30}
+        initialPageLength={100}
         paginate={true}
         searchable={true}
         initialSortBy={initialSortBy}


### PR DESCRIPTION
Set default page size to 100 #23
