### PR TITLE
Simplify rendering of mutation status in summary view

### DIFF
--- a/cancerbrowser/common/components/CellLineTable/cell_line_table.scss
+++ b/cancerbrowser/common/components/CellLineTable/cell_line_table.scss
@@ -1,5 +1,5 @@
 $cell-alternate-fill: #f4f4f4;
-$cell-muted-color: #aaa;
+$cell-muted-color: #bbb;
 
 .CellLineTable {
   .table > tbody > tr > td {
@@ -9,7 +9,7 @@ $cell-muted-color: #aaa;
     background-color: $cell-alternate-fill;
   }
 
-  .mutation-no-data {
+  .no-data {
     color: $cell-muted-color;
   }
 

--- a/cancerbrowser/common/components/CellLineTable/index.jsx
+++ b/cancerbrowser/common/components/CellLineTable/index.jsx
@@ -15,14 +15,6 @@ function labelRenderer(val) {
   return val.label;
 }
 
-function listLabelRenderer(val) {
-  return (
-    <ul className='list-inline label-list'>
-      {val.map((item, i) => <li key={i}>{item.label}</li>)}
-    </ul>
-  );
-}
-
 function commaListLabelRenderer(val) {
   return val.map(item => item.label).join(', ');
 }
@@ -49,7 +41,37 @@ const allColumns = {
   mutationStatusSummary: {
     prop: 'mutation',
     title: 'Mutation Status',
-    render: listLabelRenderer
+
+    /**
+     * Render:
+     *  - "No data" if there is no mutation data,
+     *  - "All WT" if all genes are wild type
+     *  - Otherwise a comma separated list of mutated genes
+     *
+     * @param {Array} array of mutated gene values
+     * @return {String}
+     */
+    render(val) {
+      if (/nodata$/.test(val[0].value)) {
+        return 'No data';
+      }
+
+      const mutations = val.filter(gene => /mut$/.test(gene.value));
+
+      if (!mutations.length) {
+        return 'All WT';
+      }
+
+      // take just the gene names, comma separated
+      return mutations.map(gene => gene.label.split(' ')[0]).join(', ');
+    },
+
+    // sets the class to no-data if there is no gene data
+    className(val) {
+      if (/nodata$/.test(val[0].value)) {
+        return 'no-data';
+      }
+    }
   },
   dataset: {
     title: 'Dataset',
@@ -84,7 +106,7 @@ const mutationGenesColumns = mutationGenes.map(gene => ({
     if (val) {
       return `mutation-${val.toLowerCase().replace(/ /g, '-')}`;
     } else {
-      return 'mutation-no-data';
+      return 'no-data';
     }
   }
 }));


### PR DESCRIPTION
Simplifies the mutation status column as per #67 
![image](https://cloud.githubusercontent.com/assets/793847/15586504/b58f0df0-2352-11e6-9dd4-107c661b58ef.png)
