### PR TITLE
Add in space for bar to the option renderer

### DIFF
--- a/cancerbrowser/common/components/NumberedSelectOption/numbered_select_option.scss
+++ b/cancerbrowser/common/components/NumberedSelectOption/numbered_select_option.scss
@@ -2,9 +2,10 @@ $count-width: 60px;
 
 .NumberedSelectOption {
   position: relative;
+  padding-right: $count-width;
 
   .option-label {
-    display: inline-block;
+    display: block;
   }
 
   .option-count {


### PR DESCRIPTION
Resolves #78 overlap issue with multiselect and long options
