### PR TITLE
Receptor data transformations.

### DIFF
--- a/cancerbrowser/common/api/dataset.js
+++ b/cancerbrowser/common/api/dataset.js
@@ -1,7 +1,11 @@
 import d3 from 'd3';
+import _ from 'lodash';
 // import fetch from 'isomorphic-fetch';
 
-import { DATA_PATH } from './util';
+import { DATA_PATH,
+         mergeData } from './util';
+
+import { getCellLines } from './cell_line';
 
 import datasetInfo from './data/dataset_info.json';
 
@@ -46,14 +50,93 @@ export function getDataset(datasetId) {
         if(error) {
           reject(error);
         } else {
-          resolve(transformDataset(data, info));
+          resolve(transformData(data, info));
         }
       });
 
     } else {
       reject('Not valid dataset Id ' + datasetId);
     }
+  }).then(mergeCellLines);
+}
+
+/**
+ * Merge in cell line data for each row in the dataset.
+ * Expects dataset to have `id` attribute that refers to its cell line.
+ * @param {Array} dataset
+ * @return {Array} with cell line data merged in as `cell_line` attribute.
+ */
+function mergeCellLines(dataset) {
+  return getCellLines().then(function(cellLines) {
+    return mergeData(dataset, cellLines, 'id', 'id', 'cell_line');
   });
+}
+
+/**
+ * Custom data transformations for the different datasets.
+ * @param {Array} dataset parsed dataset file
+ * @param {Object} info Info about the dataset.
+ * @return {Array} transformed data
+ */
+function transformData(dataset, info) {
+  dataset = convertStringsToNumbers(dataset, info.text_fields);
+  switch(info.id) {
+    case 'receptor_profile':
+      dataset = transformReceptorData(dataset);
+  }
+
+  return dataset;
+}
+
+/**
+ * Convert receptor data to a useable form.
+ * The receptor data has its last row as the detection thresholds.
+ * We need to associate a threshold with each detection value.
+ * Original columns look like: ERK1/2 log_{10}(pg/cell): value.
+ *
+ * Modified columns should looke like:
+ * {index:2, label:"ERK1/2 log_{10}(pg/cell)", metric:"pg/cell",
+ *  receptor:"ERK1/2", threshold:-4.6696, value:-3.3432}
+ *
+ * index indicates order in which we see the key column.
+ * threshold is pulled in from the last row.
+ *
+ * Data manipulation happens in place.
+ *
+ */
+function transformReceptorData(dataset) {
+
+  let thresholds = dataset.pop();
+
+  dataset.forEach(function(row) {
+    row.id = row['Cell Line Name'].toLowerCase();
+
+    var measurements = [];
+    _.keys(row).forEach(function(key, index) {
+      // if log is in the key, then it is a measurement
+      if(key.includes('log')) {
+
+        let measurement = {label: key,
+                           value: row[key],
+                           threshold: thresholds[key],
+                           index: index};
+        // grab a few more values.
+        let fields = key.split(' ');
+        // name of receptor
+        measurement.receptor = fields[0];
+        // get out the metric.
+        let metric = fields[1].match(/\((.*)\)/)[1];
+        measurement.metric = metric;
+
+        measurements.push(measurement);
+        // remove the original value.
+        delete row[key];
+      }
+    });
+    row.measurements = measurements;
+  });
+
+  return dataset;
 }
 
 /**
@@ -62,15 +145,14 @@ export function getDataset(datasetId) {
  * WARNING: this transformation currently occurs in place.
  *
  * @param {Array}  dataset The dataset to workon
- * @param {Object} info Information about dataset
- *  that includes text_fields attribute to indicate
- *  which columns should not be converted.
+ * @param {Array} excludedColumns array of columns that should not
+ *  be converted.
  * @return {Array} the modified dataset
  */
-function transformDataset(dataset, info) {
+function convertStringsToNumbers(dataset, excludedColumns) {
   dataset.forEach(function(row) {
     Object.keys(row).forEach(function(key) {
-      if(!info.text_fields.includes(key)) {
+      if(!excludedColumns.includes(key)) {
         row[key] = +row[key];
       }
     });

--- a/cancerbrowser/common/containers/DatasetDetailPage/index.jsx
+++ b/cancerbrowser/common/containers/DatasetDetailPage/index.jsx
@@ -43,6 +43,9 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
   });
 }
 
+/**
+ * React container for DatasetDetails page.
+ */
 class DatasetDetailPage extends React.Component {
 
   componentDidMount() {
@@ -50,43 +53,16 @@ class DatasetDetailPage extends React.Component {
     this.props.dispatch(fetchDatasetInfo(this.props.params));
   }
 
-  renderTable() {
-    let columnSet = [];
-    let data = [];
-    if(this.props.datasetDetail) {
-      columnSet = Object.keys(this.props.datasetDetail[0]).map((k) => {
-        return {prop: k, title: k, render(val) { return val; }};
-      });
-      data = this.props.datasetDetail;
-    }
-    return (
-      <SortableTable
-        className="CellLineTable"
-        keys={[this.props.datasetInfo.cell_line_id]}
-        initialData={data}
-        columns={columnSet}
-        initialPageLength={30}
-        paginate={true}
-        initialSortBy={{ prop: 'cellLine', order: 'descending' }}
-      />
-    );
-  }
-
   render() {
-
+    console.log(this.props.datasetDetail);
     return (
       <div>
         <h1>{this.props.datasetInfo.label}</h1>
-
-        {this.renderTable()}
-
 
       </div>
     );
   }
 }
-
-
 
 DatasetDetailPage.propTypes = propTypes;
 


### PR DESCRIPTION
Now receptor thresholds and data are in useable format.

Example format:

```
[
  {
    "Cell Line HMSLID": "50576",
    "Cell Line Name": "184B5",
    "id": "184b5",
    "measurements": [
      {
        "label": "ERK1/2 log_{10}(pg/cell)",
        "value": -3.3432,
        "threshold": -4.6696,
        "index": 2,
        "receptor": "ERK1/2",
        "metric": "pg/cell"
      },
      {
        "label": "Akt log_{10}(pg/cell)",
        "value": -1.8391,
        "threshold": -4.5952,
        "index": 3,
        "receptor": "Akt",
        "metric": "pg/cell"
      },
      //...
     ],
    "cell_line": {
      "BRCA1": "WT",
      "BRCA2": "MUT",
      "CDH1": "MUT",
      "MAP3K1": "WT",
      "MLL3": "MUT",
      "PIK3CA": "WT",
      "PTEN": "WT",
      "TP53": "WT",
      "MAP2K4": "WT",
      "cellLine": {
        "value": "zr-75-30",
        "label": "ZR-75-30"
      },
      "collection": [
        {
          "label": "ICBP43",
          "value": "icbp43"
        }

```
