### PR TITLE
Add receptors to redux data store

### DIFF
--- a/cancerbrowser/common/actions/receptor.js
+++ b/cancerbrowser/common/actions/receptor.js
@@ -1,0 +1,72 @@
+import api from '../api';
+
+export const SET_RECEPTORS = 'SET_RECEPTORS';
+export const REQUEST_RECEPTORS = 'REQUEST_RECEPTORS';
+
+/**
+ * Action creator for setting receptors
+ */
+function setReceptors(receptors) {
+  return {
+    type: SET_RECEPTORS,
+    receptors
+  };
+}
+
+/**
+ * Action creator for setting receptors
+ */
+function requestReceptors() {
+  return {
+    type: REQUEST_RECEPTORS
+  };
+}
+
+
+/**
+ * Helper function to get receptors
+ * @return {Function}
+ */
+function fetchReceptors() {
+  return dispatch => {
+    dispatch(requestReceptors());
+    api.getReceptors()
+    .then((data) => dispatch(setReceptors(data)));
+  };
+}
+
+/**
+ * Helper function to determine if the
+ * receptors need to be acquired.
+ */
+function shouldFetchReceptors(state) {
+  const { receptors } = state;
+
+  // If there are no receptors at all
+  if (!receptors) {
+    return true;
+  }
+
+  if (receptors.items && receptors.items.length > 0) {
+    return false;
+  }
+
+  // If is already fetching
+  if (receptors.isFetching) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Public function to acquire receptors
+ * and create action to store it.
+ */
+export function fetchReceptorsIfNeeded() {
+  return (dispatch, getState) => {
+    if (shouldFetchReceptors(getState())) {
+      return dispatch(fetchReceptors());
+    }
+  };
+}

--- a/cancerbrowser/common/api/index.js
+++ b/cancerbrowser/common/api/index.js
@@ -2,6 +2,7 @@
 import { getCellLines, getCellLineCounts, getCellLineInfo } from './cell_line';
 import { getDrugs, getDrugCounts } from './drug';
 import { getDataset, getDatasets, getDatasetInfo } from './dataset';
+import { getReceptors } from './receptor';
 
 export default {
   getDatasets,
@@ -11,5 +12,6 @@ export default {
   getCellLineCounts,
   getCellLineInfo,
   getDrugs,
-  getDrugCounts
+  getDrugCounts,
+  getReceptors
 };

--- a/cancerbrowser/common/api/receptor.js
+++ b/cancerbrowser/common/api/receptor.js
@@ -1,0 +1,12 @@
+
+import { getDataset } from './dataset';
+
+export function getReceptors() {
+  let datasetId = 'receptor_profile';
+  return getDataset(datasetId).then((receptorData) => {
+    return receptorData[0].measurements.map((measurement) => {
+
+      return {label: measurement.receptor, value: measurement.receptor.toLowerCase()};
+    });
+  });
+}

--- a/cancerbrowser/common/reducers/index.js
+++ b/cancerbrowser/common/reducers/index.js
@@ -5,6 +5,7 @@ import datasets from './datasets';
 import cellLines from './cell_lines';
 import drugs from './drugs';
 import filters from './filters';
+import receptors from './receptors';
 
 import datasetDetails from './datasetDetails';
 
@@ -14,5 +15,6 @@ export default combineReducers({
   cellLines,
   drugs,
   filters,
+  receptors,
   routing: routerReducer
 });

--- a/cancerbrowser/common/reducers/receptors.js
+++ b/cancerbrowser/common/reducers/receptors.js
@@ -1,0 +1,25 @@
+import { REQUEST_RECEPTORS, SET_RECEPTORS } from '../actions/receptor';
+
+const INITIAL_STATE = {
+  isFetching: false,
+  items: []
+};
+
+
+function receptors(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case REQUEST_RECEPTORS:
+      return Object.assign({}, state, {
+        isFetching: true
+      });
+    case SET_RECEPTORS:
+      return Object.assign({}, state, {
+        isFetching: false,
+        items: action.receptors
+      });
+    default:
+      return state;
+  }
+}
+
+export default receptors;


### PR DESCRIPTION
This loads it directly from the processed data file  - which makes it fragile if we change the data format / post processing. But it also keeps everything in sync without a preprocessing step.

Also, receptors is only retrieved once. Additional requests for data should be short-circuited. 
