### PR TITLE
Recompute groups when group by changes in drug cards

### DIFF
--- a/cancerbrowser/common/components/DrugCards/index.jsx
+++ b/cancerbrowser/common/components/DrugCards/index.jsx
@@ -101,7 +101,7 @@ class DrugCards extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.data !== this.props.data) {
+    if (nextProps.data !== this.props.data || nextProps.groupBy !== this.props.groupBy) {
       this.setState({ groups: labelValueGroupBy(nextProps.data, nextProps.groupBy) });
     }
   }


### PR DESCRIPTION
When group by changed, it didn't update the groups, so it did nothing.
