### PR TITLE
Reset filters when leaving a page

### DIFF
--- a/cancerbrowser/common/actions/filter.js
+++ b/cancerbrowser/common/actions/filter.js
@@ -1,9 +1,16 @@
 
 export const CHANGE_ACTIVE_FILTERS = 'CHANGE_ACTIVE_FILTERS';
+export const RESET_ACTIVE_FILTERS = 'RESET_ACTIVE_FILTERS';
 
 export function changeActiveFilters(activeFilters) {
   return {
     type: CHANGE_ACTIVE_FILTERS,
     activeFilters
+  };
+}
+
+export function resetActiveFilters() {
+  return {
+    type: RESET_ACTIVE_FILTERS
   };
 }

--- a/cancerbrowser/common/containers/CellLineBrowserPage/index.jsx
+++ b/cancerbrowser/common/containers/CellLineBrowserPage/index.jsx
@@ -17,7 +17,8 @@ import {
 } from '../../actions/cell_line';
 
 import {
-  changeActiveFilters
+  changeActiveFilters,
+  resetActiveFilters
 } from '../../actions/filter';
 
 const propTypes = {
@@ -138,6 +139,14 @@ class CellLineBrowserPage extends React.Component {
   componentDidMount() {
     this.props.dispatch(fetchCellLinesIfNeeded({}, filterGroups));
     this.props.dispatch(fetchDatasetsInfo());
+  }
+
+  /*
+   * Reset the active filters when leaving the page.
+   * this prevents cellLineFilters set here affecting other pages
+   */
+  componentWillUnmount() {
+    this.props.dispatch(resetActiveFilters());
   }
 
   onFilterChange(newFilters) {

--- a/cancerbrowser/common/containers/DrugBrowserPage/index.jsx
+++ b/cancerbrowser/common/containers/DrugBrowserPage/index.jsx
@@ -16,7 +16,8 @@ import {
 } from '../../actions/drug';
 
 import {
-  changeActiveFilters
+  changeActiveFilters,
+  resetActiveFilters
 } from '../../actions/filter';
 
 const propTypes = {
@@ -82,6 +83,15 @@ class DrugBrowserPage extends React.Component {
     dispatch(fetchDrugsIfNeeded({}, {}));
     dispatch(fetchDrugFilters());
   }
+
+  /*
+   * Reset the active filters when leaving the page.
+   * this prevents drugFilters set here affecting other pages
+   */
+  componentWillUnmount() {
+    this.props.dispatch(resetActiveFilters());
+  }
+
 
   onFilterChange(newFilters) {
     const { dispatch } = this.props;

--- a/cancerbrowser/common/reducers/filters.js
+++ b/cancerbrowser/common/reducers/filters.js
@@ -1,6 +1,6 @@
 
 
-import { CHANGE_ACTIVE_FILTERS } from '../actions/filter';
+import { CHANGE_ACTIVE_FILTERS, RESET_ACTIVE_FILTERS } from '../actions/filter';
 
 const INITIAL_STATE = {
   active: {},
@@ -14,6 +14,8 @@ function filters(state = INITIAL_STATE, action) {
         isFetching: false,
         active: action.activeFilters
       });
+    case RESET_ACTIVE_FILTERS:
+      return INITIAL_STATE;
     default:
       return state;
   }


### PR DESCRIPTION
Resets filters when leaving Cell Line Browser or Drug Browser pages, resolves #120. Another solution would have been to specify which filterGroups apply to the page when doing something like fetchCellLines e.g. `fetchCellLines(filters, filterGroups, ['cellLineFilters'])` or to specify the filterGroups directly as an array: 

``` js
fetchCellLines(filters, _.compact(relevantFilterGroupKeys.map(key => filterGroups[key])))
```
