### PR TITLE
Make it so some filters can't be cleared

### DIFF
--- a/cancerbrowser/common/components/FilterPanel/index.jsx
+++ b/cancerbrowser/common/components/FilterPanel/index.jsx
@@ -233,10 +233,11 @@ class FilterPanel extends React.Component {
    * @param {Object} filter The filter being rendered (e.g. { id: 'collection', values: [...]})
    * @param {Object} activeValuesObj The values object from the active filter
    * @param {Object} filterCounts The counts information for the filter (e.g. { counts: { big6: 6 }, countMax: 9 })
-   * @param {String} groupId The ID of the filter group
+   * @param {Object} filterGroup The filter group object
    */
-  renderFilter(filter, activeValuesObj, filterCounts, groupId, index) {
+  renderFilter(filter, activeValuesObj, filterCounts, filterGroup, index) {
     let filterElem;
+    const groupId = filterGroup.id;
 
     // we only need the array of values, not the whole obj since we have the filter obj itself
     const activeValues = activeValuesObj && activeValuesObj.values;
@@ -256,12 +257,13 @@ class FilterPanel extends React.Component {
     }
 
     const hasActiveFilters = activeValuesObj && activeValuesObj.values.length;
+    const clearable = filter.clearable !== false && filterGroup.clearable !== false;
 
     return (
       <div key={index} className='filter-panel-filter'>
         <header>
           {filter.label}
-          {hasActiveFilters ? (
+          {hasActiveFilters && clearable ? (
             <Icon name='close'
               title={`Reset ${filter.label}`}
               className='reset-filter-control clickable-icon'
@@ -294,11 +296,13 @@ class FilterPanel extends React.Component {
         && activeFiltersForGroup.some(activeFilter =>
           group.filters.some(filter => filter.id === activeFilter.id));
 
+    const clearable = group.clearable !== false;
+
     return (
       <div key={index} className='filter-panel-group'>
         <header>
           {group.label}
-          {hasActiveFilters ? (
+          {hasActiveFilters && clearable ? (
             <Icon name='close'
               title={`Reset ${group.label}`}
               className='reset-group-control clickable-icon'
@@ -316,7 +320,7 @@ class FilterPanel extends React.Component {
               filterCounts = countsForGroup[filter.id];
             }
 
-            return this.renderFilter(filter, activeValues, filterCounts, group.id, i);
+            return this.renderFilter(filter, activeValues, filterCounts, group, i);
           })}
         </div>
       </div>

--- a/cancerbrowser/common/selectors/datasetGrowthFactorPaktPerk.js
+++ b/cancerbrowser/common/selectors/datasetGrowthFactorPaktPerk.js
@@ -202,6 +202,7 @@ export const getFilterGroups = createSelector(
       filterGroups.push({
         id: 'growthFactorConfig',
         label: 'Configure',
+        clearable: false,
         filters: growthFactorConfiguration
       });
     }

--- a/cancerbrowser/common/selectors/datasetReceptorProfile.js
+++ b/cancerbrowser/common/selectors/datasetReceptorProfile.js
@@ -82,7 +82,7 @@ function filterReceptorDataByCellLine(data, cellLines) {
 
 /**
  * For 1 cell line x all receptors view, we don't want to display AU
- * values - so filter them. 
+ * values - so filter them.
  */
 function filterByMetric(dataset, metricToKeep) {
   if (!dataset) {
@@ -157,6 +157,7 @@ export const getFilterGroups = createSelector(
       filterGroups.push({
         id: 'byReceptorConfig',
         label: 'Configure',
+        clearable: false,
         filters: byReceptorConfig
       });
 
@@ -194,6 +195,7 @@ export const getFilterGroups = createSelector(
       filterGroups.push({
         id: 'byCellLineConfig',
         label: 'Configure',
+        clearable: false,
         filters: byCellLineConfig
       });
     }


### PR DESCRIPTION
Set the configure filters to not have "X" clear buttons next to them.

![image](https://cloud.githubusercontent.com/assets/793847/15795954/61a4e886-29c4-11e6-907a-5d1b53a8b1d4.png)
