### PR TITLE
Animate waterfall plot

### DIFF
--- a/cancerbrowser/common/components/WaterfallPlot/waterfall.js
+++ b/cancerbrowser/common/components/WaterfallPlot/waterfall.js
@@ -126,7 +126,7 @@ class Waterfall {
       .call(xAxis);
 
     // animation variables
-    const transitionDuration = 500;
+    const transitionDuration = 300;
     const transitionDelay = (d, i) => i * 5;
 
     const labels = this.g


### PR DESCRIPTION
Handles turning on and off useThreshold parameter

Gif here shows 500ms, but reduced to 300ms now
![animated_chart](https://cloud.githubusercontent.com/assets/793847/15826052/0fb38a8e-2bd4-11e6-94a5-1fdda6a3447e.gif)
