### PR TITLE
Use consistent normalization functions to create cell line id’s with no dashes.

### DIFF
--- a/cancerbrowser/common/api/cell_line.js
+++ b/cancerbrowser/common/api/cell_line.js
@@ -10,6 +10,8 @@ import {
 //TODO async load cell line data.
 import cellLinesData from  './data/cell_lines.json';
 
+import { normalize } from '../../common/utils/string_utils';
+
 /**
  * Returns cell lines data
  *
@@ -42,7 +44,7 @@ export function getCellLineInfos() {
         } else {
 
           // add consistent ID value for matching.
-          data.forEach((d) => d.id = d['Cell Line'].toLowerCase());
+          data.forEach((d) => d.id = normalize(d['Cell Line']));
 
           let results = mergeData(allCellLines, data, 'id', 'id', 'info');
           resolve(results);
@@ -62,9 +64,9 @@ export function getCellLineInfo(cellLineId) {
   return getCellLineInfos().then(function(allCellLineInfos) {
     return new Promise(function(resolve, reject) {
 
-      var cellLinesByName = _.keyBy(allCellLineInfos, 'id');
+      const cellLinesByName = _.keyBy(allCellLineInfos, 'id');
 
-      var cellLine = cellLinesByName[cellLineId];
+      const cellLine = cellLinesByName[cellLineId];
 
       if(cellLine) {
         resolve(cellLine);
@@ -74,4 +76,3 @@ export function getCellLineInfo(cellLineId) {
     });
   });
 }
-

--- a/cancerbrowser/common/api/data/cell_lines.json
+++ b/cancerbrowser/common/api/data/cell_lines.json
@@ -93,7 +93,7 @@
     "TP53": "MUT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "au-565",
+      "value": "au565",
       "label": "AU-565"
     },
     "collection": [
@@ -153,8 +153,17 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "au-565",
-    "dataset": []
+    "id": "au565",
+    "dataset": [
+      {
+        "value": "receptor_profile",
+        "label": "Basal Receptor (RTK) Profile"
+      },
+      {
+        "value": "growth_factor_pakt_perk",
+        "label": "Growth Factor-Induced pAKT/pERK Response"
+      }
+    ]
   },
   {
     "BRCA1": "WT",
@@ -167,7 +176,7 @@
     "TP53": "MUT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "bt-20",
+      "value": "bt20",
       "label": "BT-20"
     },
     "collection": [
@@ -231,7 +240,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "bt-20",
+    "id": "bt20",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -266,7 +275,7 @@
     "TP53": "MUT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "bt-474",
+      "value": "bt474",
       "label": "BT-474"
     },
     "collection": [
@@ -326,7 +335,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "bt-474",
+    "id": "bt474",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -349,7 +358,7 @@
     "TP53": "MUT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "bt-483",
+      "value": "bt483",
       "label": "BT-483"
     },
     "collection": [
@@ -409,7 +418,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "bt-483",
+    "id": "bt483",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -432,7 +441,7 @@
     "TP53": "WT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "bt-549",
+      "value": "bt549",
       "label": "BT-549"
     },
     "collection": [
@@ -492,7 +501,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "bt-549",
+    "id": "bt549",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -523,7 +532,7 @@
     "TP53": "MUT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "cama-1",
+      "value": "cama1",
       "label": "CAMA-1"
     },
     "collection": [
@@ -583,7 +592,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "cama-1",
+    "id": "cama1",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -2269,7 +2278,7 @@
     "TP53": "No data",
     "MAP2K4": "No data",
     "cellLine": {
-      "value": "mcf-12a",
+      "value": "mcf12a",
       "label": "MCF-12A"
     },
     "collection": [
@@ -2329,8 +2338,17 @@
         "label": "MAP2K4 No data"
       }
     ],
-    "id": "mcf-12a",
-    "dataset": []
+    "id": "mcf12a",
+    "dataset": [
+      {
+        "value": "receptor_profile",
+        "label": "Basal Receptor (RTK) Profile"
+      },
+      {
+        "value": "growth_factor_pakt_perk",
+        "label": "Growth Factor-Induced pAKT/pERK Response"
+      }
+    ]
   },
   {
     "BRCA1": "WT",
@@ -2343,7 +2361,7 @@
     "TP53": "WT",
     "MAP2K4": "MUT",
     "cellLine": {
-      "value": "mda-mb-134-vi",
+      "value": "mdamb134vi",
       "label": "MDA-MB-134-VI"
     },
     "collection": [
@@ -2403,7 +2421,7 @@
         "label": "MAP2K4 MUT"
       }
     ],
-    "id": "mda-mb-134-vi",
+    "id": "mdamb134vi",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -2426,7 +2444,7 @@
     "TP53": "MUT*",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "mda-mb-157",
+      "value": "mdamb157",
       "label": "MDA-MB-157"
     },
     "collection": [
@@ -2486,7 +2504,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "mda-mb-157",
+    "id": "mdamb157",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -2509,7 +2527,7 @@
     "TP53": "WT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "mda-mb-175-vii",
+      "value": "mdamb175vii",
       "label": "MDA-MB-175-VII"
     },
     "collection": [
@@ -2569,7 +2587,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "mda-mb-175-vii",
+    "id": "mdamb175vii",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -2592,7 +2610,7 @@
     "TP53": "MUT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "mda-mb-231",
+      "value": "mdamb231",
       "label": "MDA-MB-231"
     },
     "collection": [
@@ -2656,7 +2674,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "mda-mb-231",
+    "id": "mdamb231",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -2665,6 +2683,14 @@
       {
         "value": "growth_factor_pakt_perk",
         "label": "Growth Factor-Induced pAKT/pERK Response"
+      },
+      {
+        "value": "basal_total",
+        "label": "Basal Total Protein Mass Spectrometry"
+      },
+      {
+        "value": "basal_phospho",
+        "label": "Basal Phosphoprotein Mass Spectrometry"
       },
       {
         "value": "drug_dose_response",
@@ -2683,7 +2709,7 @@
     "TP53": "MUT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "mda-mb-361",
+      "value": "mdamb361",
       "label": "MDA-MB-361"
     },
     "collection": [
@@ -2743,7 +2769,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "mda-mb-361",
+    "id": "mdamb361",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -2766,7 +2792,7 @@
     "TP53": "MUT",
     "MAP2K4": "MUT",
     "cellLine": {
-      "value": "mda-mb-415",
+      "value": "mdamb415",
       "label": "MDA-MB-415"
     },
     "collection": [
@@ -2826,7 +2852,7 @@
         "label": "MAP2K4 MUT"
       }
     ],
-    "id": "mda-mb-415",
+    "id": "mdamb415",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -2849,7 +2875,7 @@
     "TP53": "WT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "mda-mb-436",
+      "value": "mdamb436",
       "label": "MDA-MB-436"
     },
     "collection": [
@@ -2909,7 +2935,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "mda-mb-436",
+    "id": "mdamb436",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -2932,7 +2958,7 @@
     "TP53": "WT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "mda-mb-453",
+      "value": "mdamb453",
       "label": "MDA-MB-453"
     },
     "collection": [
@@ -2992,7 +3018,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "mda-mb-453",
+    "id": "mdamb453",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -3015,7 +3041,7 @@
     "TP53": "WT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "mda-mb-468",
+      "value": "mdamb468",
       "label": "MDA-MB-468"
     },
     "collection": [
@@ -3075,7 +3101,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "mda-mb-468",
+    "id": "mdamb468",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -3098,7 +3124,7 @@
     "TP53": "MUT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "sk-br-3",
+      "value": "skbr3",
       "label": "SK-BR-3"
     },
     "collection": [
@@ -3162,7 +3188,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "sk-br-3",
+    "id": "skbr3",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -3171,6 +3197,14 @@
       {
         "value": "growth_factor_pakt_perk",
         "label": "Growth Factor-Induced pAKT/pERK Response"
+      },
+      {
+        "value": "basal_total",
+        "label": "Basal Total Protein Mass Spectrometry"
+      },
+      {
+        "value": "basal_phospho",
+        "label": "Basal Phosphoprotein Mass Spectrometry"
       },
       {
         "value": "drug_dose_response",
@@ -3272,7 +3306,7 @@
     "TP53": "WT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "uacc-812",
+      "value": "uacc812",
       "label": "UACC-812"
     },
     "collection": [
@@ -3332,7 +3366,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "uacc-812",
+    "id": "uacc812",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -3355,7 +3389,7 @@
     "TP53": "MUT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "uacc-893",
+      "value": "uacc893",
       "label": "UACC-893"
     },
     "collection": [
@@ -3415,7 +3449,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "uacc-893",
+    "id": "uacc893",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -3438,7 +3472,7 @@
     "TP53": "WT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "zr-75-1",
+      "value": "zr751",
       "label": "ZR-75-1"
     },
     "collection": [
@@ -3498,7 +3532,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "zr-75-1",
+    "id": "zr751",
     "dataset": [
       {
         "value": "receptor_profile",
@@ -3521,7 +3555,7 @@
     "TP53": "WT",
     "MAP2K4": "WT",
     "cellLine": {
-      "value": "zr-75-30",
+      "value": "zr7530",
       "label": "ZR-75-30"
     },
     "collection": [
@@ -3581,7 +3615,7 @@
         "label": "MAP2K4 WT"
       }
     ],
-    "id": "zr-75-30",
+    "id": "zr7530",
     "dataset": [
       {
         "value": "receptor_profile",

--- a/cancerbrowser/common/api/data/dataset_info.json
+++ b/cancerbrowser/common/api/data/dataset_info.json
@@ -28,7 +28,7 @@
     "id": "basal_total",
     "label": "Basal Total Protein Mass Spectrometry",
     "filename": "basal_total_proteome-numerical_view.tsv",
-    "cell_lines": ["hcc1806", "mcf10a", "hcc38", "bt-549", "hs578t", "mdamb231", "skbr3", "mcf7", "hcc70", "bt-20"],
+    "cell_lines": ["hcc1806", "mcf10a", "hcc38", "bt549", "hs578t", "mdamb231", "skbr3", "mcf7", "hcc70", "bt20"],
     "row_id": "Total protein by cell line",
     "text_fields": ["Total protein by cell line"]
   },
@@ -36,7 +36,7 @@
     "id": "basal_phospho",
     "label": "Basal Phosphoprotein Mass Spectrometry",
     "filename": "basal_phosphoproteome-numerical_view.tsv",
-    "cell_lines": ["bt-549","hs578t","mdamb231","skbr3","hcc70","mcf7","bt-20","hcc38","hcc1806","mcf10a"],
+    "cell_lines": ["bt549","hs578t","mdamb231","skbr3","hcc70","mcf7","bt20","hcc38","hcc1806","mcf10a"],
     "row_id": "Phosphosite by cell line",
     "text_fields": ["Phosphosite by cell line"]
   },

--- a/cancerbrowser/common/api/dataset.js
+++ b/cancerbrowser/common/api/dataset.js
@@ -1,6 +1,5 @@
 import d3 from 'd3';
 import _ from 'lodash';
-// import fetch from 'isomorphic-fetch';
 
 import { DATA_PATH,
          mergeData } from './util';
@@ -9,6 +8,7 @@ import { getCellLines } from './cell_line';
 
 import datasetInfo from './data/dataset_info.json';
 
+import { normalize } from '../../common/utils/string_utils';
 
 /** Returns Promise that resolves to information about
  * each dataset in an Object where
@@ -119,7 +119,7 @@ function transformData(dataset, info) {
 function transformDoseResponse(dataset, info) {
   dataset.forEach(function(row) {
     row.label = row[info.row_id];
-    row.id = row.label.toLowerCase();
+    row.id = normalize(row.label);
   });
   return dataset;
 }
@@ -134,7 +134,7 @@ function transformGrowthFactor(dataset, info) {
 
   dataset.forEach(function(row) {
     row.label = row[info.row_id];
-    row.id = row.label.toLowerCase();
+    row.id = normalize(row.label);
 
     const measurements = [];
     _.keys(row).forEach(function(key, index) {
@@ -171,7 +171,7 @@ function transformGrowthFactor(dataset, info) {
 function transformBasalTotal(dataset, info) {
   dataset.forEach(function(row) {
     row.label = row[info.row_id];
-    row.id = row.label.toLowerCase();
+    row.id = normalize(row.label);
   });
   return dataset;
 }
@@ -188,7 +188,7 @@ function transformBasalPhospho(dataset, info) {
     // in the id column.
     const idFields = row[info.row_id].split(' ');
     row.label = idFields[0];
-    row.id = row.label.toLowerCase();
+    row.id = normalize(row.label);
 
     row.descriptor = idFields[1];
   });
@@ -218,7 +218,7 @@ function transformReceptorData(dataset) {
 
 
   dataset.forEach(function(row) {
-    row.id = row['Cell Line Name'].toLowerCase();
+    row.id = normalize(row['Cell Line Name']);
     row.label = row['Cell Line Name'];
 
     const measurements = [];
@@ -235,7 +235,7 @@ function transformReceptorData(dataset) {
         // name of receptor
         measurement.receptor = fields[0];
         measurement.label = fields[0];
-        measurement.id = fields[0].toLowerCase();
+        measurement.id = normalize(fields[0]);
         if(measurement.value === measurement.threshold) {
           measurement.disabled = true;
         }

--- a/cancerbrowser/common/api/receptor.js
+++ b/cancerbrowser/common/api/receptor.js
@@ -1,12 +1,14 @@
 
 import { getDataset } from './dataset';
 
+import { normalize } from '../../common/utils/string_utils';
+
 export function getReceptors() {
   let datasetId = 'receptor_profile';
   return getDataset(datasetId).then((receptorData) => {
     return receptorData[0].measurements.map((measurement) => {
 
-      return {label: measurement.receptor, value: measurement.receptor.toLowerCase()};
+      return {label: measurement.receptor, value: normalize(measurement.receptor)};
     });
   });
 }

--- a/cancerbrowser/common/components/OmniSearch/index.jsx
+++ b/cancerbrowser/common/components/OmniSearch/index.jsx
@@ -4,6 +4,8 @@ import shallowCompare from 'react-addons-shallow-compare';
 
 import _ from 'lodash';
 
+import { normalize } from '../../utils/string_utils';
+
 import './omni_search.scss';
 
 const propTypes = {
@@ -104,7 +106,7 @@ class OmniSearch extends React.Component {
   * @return {String} search term we are searching for
   */
   getSuggestions(search) {
-    search = search.trim().toLowerCase();
+    search = normalize(search.trim());
 
     if(search.length > 0) {
 
@@ -123,8 +125,8 @@ class OmniSearch extends React.Component {
 
             // handle array value of strings (e.g. synonyms, searchIndexOnlyNames)
             if (_.isArray(searchAttrValue)) {
-              matches = searchAttrValue.some(val => val.toLowerCase().includes(search));
-            } else if(searchAttrValue.toLowerCase().includes(search)) {
+              matches = searchAttrValue.some(val => normalize(val).includes(search));
+            } else if(normalize(searchAttrValue).includes(search)) {
               matches = true;
             }
 
@@ -172,7 +174,6 @@ class OmniSearch extends React.Component {
   * @param {String} value New search value
   */
   onSuggestionsUpdateRequested({ value }) {
-    // const term = value.trim().toLowerCase();
     this.setState({
       suggestions: this.getSuggestions(value)
     });
@@ -200,7 +201,7 @@ class OmniSearch extends React.Component {
 
     // include searchIndexOnlyName if it matches
     if (suggestion.searchIndexOnlyNames && suggestion.searchIndexOnlyNames.length) {
-      const match = suggestion.searchIndexOnlyNames.find(searchName => searchName.toLowerCase().includes(search.toLowerCase()));
+      const match = suggestion.searchIndexOnlyNames.find(searchName => normalize(searchName).includes(normalize(search)));
       if (match) {
         synonymsToUse.push(match);
       }

--- a/cancerbrowser/common/utils/string_utils.js
+++ b/cancerbrowser/common/utils/string_utils.js
@@ -17,7 +17,7 @@ export function plural(items, word, pluralSuffix = 's') {
 
 // helper function to normalize a string for search comparison by lower casing and trimming
 export function normalize(str) {
-  return String(str).toLowerCase().trim();
+  return String(str).toLowerCase().replace(/-/g,'').replace(/\s/g,'').trim();
 }
 
 // helper function to convert an array of strings to a comma separated list

--- a/cancerbrowser/tools/Makefile
+++ b/cancerbrowser/tools/Makefile
@@ -14,3 +14,5 @@ move_drugs:
 	mv drugs.json ../common/api/data/
 
 all: cell_lines move_cell_lines drugs move_drugs
+
+default: all

--- a/cancerbrowser/tools/add_datasets_to_cell_lines.js
+++ b/cancerbrowser/tools/add_datasets_to_cell_lines.js
@@ -1,18 +1,22 @@
 #!/usr/bin/env node
+'use strict';
 
-var fs = require('fs');
-var d3 = require('d3');
-var _  = require('lodash');
+const fs = require('fs');
+const d3 = require('d3');
+const _  = require('lodash');
+
+const utils = require('./utils');
+
 
 // cell_lines.json is first param
-var filename = process.argv[2];
+const filename = process.argv[2];
 
 // dataset_info.json is second
-var datasetInfoFilename = process.argv[3];
+const datasetInfoFilename = process.argv[3];
 
-var datasetRoot = '../data/datasets/';
+const datasetRoot = '../data/datasets/';
 
-var cellLines = require('./' + filename);
+const cellLines = require('./' + filename);
 
 // add a spot for datasets we will populate in a bit
 cellLines.forEach(function(cl) {
@@ -20,12 +24,12 @@ cellLines.forEach(function(cl) {
 });
 
 // pull in the dataset info
-var datasetInfo = require(datasetInfoFilename);
+const datasetInfo = require(datasetInfoFilename);
 
 // dataset info is an object, each key is a dataset id.
 Object.keys(datasetInfo).forEach(function(key) {
 
-  var info = datasetInfo[key];
+  const info = datasetInfo[key];
 
   // skip if not primary entry for the dataset
   if (info.exclude_from_datasets) {
@@ -33,18 +37,18 @@ Object.keys(datasetInfo).forEach(function(key) {
   }
 
   // the values are info objects.
-  var filename = datasetRoot + info.filename;
+  const filename = datasetRoot + info.filename;
 
 
   // read the data file
-  var data = fs.readFileSync(filename, 'utf8');
+  let data = fs.readFileSync(filename, 'utf8');
 
   // convert to tsv
   data = d3.tsv.parse(data);
 
   // Some of our datasets have the cell lines as column names instead of
   // attributes, so I have manually encoded this in our dataset info
-  var cellLinesInDataset = info.cell_lines;
+  let cellLinesInDataset = info.cell_lines;
 
   // if this isn't the case, then we can extract it from our datasets
 
@@ -52,7 +56,7 @@ Object.keys(datasetInfo).forEach(function(key) {
     // pull out all the unique cell line names.
     // we convert to lowercase here to match the id values of our
     //  cell_lines.json data.
-    cellLinesInDataset = data.map(d => d[info.cell_line_id].split(' ')[0].toLowerCase());
+    cellLinesInDataset = data.map(d => utils.getId(d[info.cell_line_id].split(' ')[0]));
 
     cellLinesInDataset = _.uniq(cellLinesInDataset);
   }

--- a/cancerbrowser/tools/add_datasets_to_drugs.js
+++ b/cancerbrowser/tools/add_datasets_to_drugs.js
@@ -1,18 +1,19 @@
 #!/usr/bin/env node
+'use strict';
 
-var fs = require('fs');
-var d3 = require('d3');
-var _  = require('lodash');
+const fs = require('fs');
+const d3 = require('d3');
+const _  = require('lodash');
 
 // cell_lines.json is first param
-var filename = process.argv[2];
+const filename = process.argv[2];
 
 // dataset_info.json is second
-var datasetInfoFilename = process.argv[3];
+const datasetInfoFilename = process.argv[3];
 
-var datasetRoot = '../data/datasets/';
+const datasetRoot = '../data/datasets/';
 
-var drugs = require('./' + filename);
+const drugs = require('./' + filename);
 
 // add a spot for datasets we will populate in a bit
 drugs.forEach(function(cl) {
@@ -20,11 +21,11 @@ drugs.forEach(function(cl) {
 });
 
 // pull in the dataset info
-var datasetInfo = require(datasetInfoFilename);
+const datasetInfo = require(datasetInfoFilename);
 
 // dataset info is an object, each key is a dataset id.
 Object.keys(datasetInfo).forEach(function(key) {
-  var info = datasetInfo[key];
+  const info = datasetInfo[key];
 
   // skip if no drug id defined
   if (!info.drug_id) {
@@ -37,11 +38,11 @@ Object.keys(datasetInfo).forEach(function(key) {
   }
 
   // the values are info objects.
-  var filename = datasetRoot + info.filename;
+  const filename = datasetRoot + info.filename;
 
 
   // read the data file
-  var data = fs.readFileSync(filename, 'utf8');
+  let data = fs.readFileSync(filename, 'utf8');
 
   // convert to tsv
   data = d3.tsv.parse(data);
@@ -49,7 +50,7 @@ Object.keys(datasetInfo).forEach(function(key) {
   // pull out all the unique drug names.
   // we convert to lowercase here to match the id values of our
   //  cell_lines.json data.
-  var drugsInDataset = data.map(d => d[info.drug_id]);
+  let drugsInDataset = data.map(d => d[info.drug_id]);
 
   drugsInDataset = _.uniq(drugsInDataset);
 

--- a/cancerbrowser/tools/utils.js
+++ b/cancerbrowser/tools/utils.js
@@ -1,6 +1,7 @@
+
 Object.prototype.renameProperty = function (oldName, newName) {
   // Do nothing if the names are the same
-  if (oldName == newName) {
+  if (oldName === newName) {
     return this;
   }
   // Check for the old property name to avoid a ReferenceError in strict mode.
@@ -9,4 +10,19 @@ Object.prototype.renameProperty = function (oldName, newName) {
     delete this[oldName];
   }
   return this;
+};
+
+function lowerFirstLetter(string) {
+  return string.charAt(0).toLowerCase() + string.slice(1);
+}
+
+function getId(label) {
+  return  label.toLowerCase().replace(/-/g,'').replace(/\s/g,'').trim();
+}
+
+
+
+module.exports = {
+  lowerFirstLetter: lowerFirstLetter,
+  getId: getId
 };


### PR DESCRIPTION
Search now ignores dashes and spaces as well. 

<img width="684" alt="screen shot 2016-06-06 at 8 28 01 am" src="https://cloud.githubusercontent.com/assets/9369/15828793/99622fe2-2bc5-11e6-910c-ccecad306e5b.png">

<img width="546" alt="screen shot 2016-06-06 at 9 01 10 am" src="https://cloud.githubusercontent.com/assets/9369/15828797/9ee244d4-2bc5-11e6-850c-0cb4470c74e2.png">

Fixes some cell line - to - dataset mappings.
