### PR TITLE
save filter in url.

### DIFF
--- a/cancerbrowser/package.json
+++ b/cancerbrowser/package.json
@@ -48,6 +48,7 @@
     "lodash": "^4.13.1",
     "mocha": "^2.5.1",
     "node-sass": "^3.7.0",
+    "qs": "^6.2.0",
     "react": "^15.1.0",
     "react-addons-shallow-compare": "^15.1.0",
     "react-autosuggest": "^3.7.4",


### PR DESCRIPTION
Well, this took too long for me to figure out.

here we use the browser `replace` to clobber the url and have it include the fllter parameters. 
This will make linking to cell line page and moving from cell line page to another page and back work.

The `replace` means we will not capture all permutations of the filters in the browser history -but just the last one. This is ok to start, in my opinion, as it captures the 2 most desirable features. 

It also makes the url really long - which we could encode more "smartly" if we wanted to. 
