### PR TITLE
Share configuration across views in perk/pakt, resolves #208

### DIFF
--- a/cancerbrowser/common/containers/DatasetGrowthFactorPaktPerkPage/index.jsx
+++ b/cancerbrowser/common/containers/DatasetGrowthFactorPaktPerkPage/index.jsx
@@ -157,24 +157,24 @@ class DatasetGrowthFactorPaktPerkPage extends DatasetBasePage {
   initView(activeId) {
     const { dispatch, activeFilters } = this.props;
     dispatch(changeViewBy('cellLine'));
-    let newFilters = updateFilterValues(activeFilters, 'cellLineConfig', 'cellLine', [activeId]);
+    let newFilters = updateFilterValues(activeFilters, 'datasetConfig', 'cellLine', [activeId]);
     dispatch(changeActiveFilters(newFilters));
   }
 
   getActiveGrowthFactor() {
     const { filterGroups, activeFilters } = this.props;
-    return getFilterValueItem(filterGroups, activeFilters, 'growthFactorConfig', 'growthFactor');
+    return getFilterValueItem(filterGroups, activeFilters, 'datasetConfig', 'growthFactor');
   }
 
   getActiveCellLine() {
     const { filterGroups, activeFilters } = this.props;
-    return getFilterValueItem(filterGroups, activeFilters, 'cellLineConfig', 'cellLine');
+    return getFilterValueItem(filterGroups, activeFilters, 'datasetConfig', 'cellLine');
   }
 
   getActiveParameter() {
-    const { filterGroups, activeFilters, viewBy } = this.props;
+    const { filterGroups, activeFilters } = this.props;
 
-    const filterGroupId = `${viewBy}Config`;
+    const filterGroupId = 'datasetConfig';
     return getFilterValueItem(filterGroups, activeFilters, filterGroupId, 'parameter');
   }
 
@@ -214,8 +214,8 @@ class DatasetGrowthFactorPaktPerkPage extends DatasetBasePage {
   }
 
   getActiveConcentration() {
-    const { activeFilters, viewBy } = this.props;
-    const filterGroupId = `${viewBy}Config`;
+    const { activeFilters } = this.props;
+    const filterGroupId = 'datasetConfig';
 
     return getFilterValue(activeFilters, filterGroupId, 'concentration');
   }

--- a/cancerbrowser/common/reducers/datasetGrowthFactorPaktPerk.js
+++ b/cancerbrowser/common/reducers/datasetGrowthFactorPaktPerk.js
@@ -20,11 +20,7 @@ const INITIAL_STATE = {
   },
 
   activeFilters: {
-    growthFactorConfig: [
-      { id: 'concentration', values: ['1'] },
-      { id: 'parameter', values: ['paktFoldChange'] }
-    ],
-    cellLineConfig: [
+    datasetConfig: [
       { id: 'concentration', values: ['1'] },
       { id: 'parameter', values: ['paktFoldChange'] }
     ]

--- a/cancerbrowser/common/selectors/datasetGrowthFactorPaktPerk.js
+++ b/cancerbrowser/common/selectors/datasetGrowthFactorPaktPerk.js
@@ -17,24 +17,22 @@ const datasetKey = 'datasetGrowthFactorPaktPerk';
 
 function getActiveGrowthFactor(state) {
   const activeFilters = state.datasets[datasetKey].activeFilters;
-  return getFilterValue(activeFilters, 'growthFactorConfig', 'growthFactor');
+  return getFilterValue(activeFilters, 'datasetConfig', 'growthFactor');
 }
 
 function getActiveCellLine(state) {
   const activeFilters = state.datasets[datasetKey].activeFilters;
-  return getFilterValue(activeFilters, 'cellLineConfig', 'cellLine');
+  return getFilterValue(activeFilters, 'datasetConfig', 'cellLine');
 }
 
 function getActiveParameter(state) {
-  const viewBy = getViewBy(datasetKey, state);
   const activeFilters = state.datasets[datasetKey].activeFilters;
-  return getFilterValue(activeFilters, `${viewBy}Config`, 'parameter');
+  return getFilterValue(activeFilters, 'datasetConfig', 'parameter');
 }
 
 function getActiveConcentration(state) {
-  const viewBy = getViewBy(datasetKey, state);
   const activeFilters = state.datasets[datasetKey].activeFilters;
-  return getFilterValue(activeFilters, `${viewBy}Config`, 'concentration');
+  return getFilterValue(activeFilters, 'datasetConfig', 'concentration');
 }
 
 function getActiveMetricAndType(state) {
@@ -273,8 +271,11 @@ export const getFilterGroups = createSelector(
         concentration
       ];
 
+
+      // important that in this view and in cell line view they use the same ID to share state
+      // (i.e., the selected parameter and concentration)
       filterGroups.push({
-        id: 'growthFactorConfig',
+        id: 'datasetConfig',
         label: 'Configure',
         clearable: false,
         filters: growthFactorConfiguration
@@ -315,7 +316,7 @@ export const getFilterGroups = createSelector(
       ];
 
       filterGroups.push({
-        id: 'cellLineConfig',
+        id: 'datasetConfig',
         label: 'Configure',
         clearable: false,
         filters: cellLineConfiguration


### PR DESCRIPTION
Resolves #208 by combining `growthFactorConfig` and `cellLineConfig` into `datasetConfig` so that parameter and concentration are only set once
