### PR TITLE
Add in parentMayResize and defaultRenderWidth flags to AutoWidth

### DIFF
--- a/cancerbrowser/common/components/AutoWidth/index.jsx
+++ b/cancerbrowser/common/components/AutoWidth/index.jsx
@@ -2,19 +2,30 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import _ from 'lodash';
 const propTypes = {
-  children: React.PropTypes.object
+  children: React.PropTypes.object,
+
+  /* If true, the component checks on componentDidUpdate to see if it needs to resize */
+  parentMayResize: React.PropTypes.bool,
+
+  /* If set, the default width is set to this value and the child is
+     rendered. If null, the child is not rendered until a width is provided */
+  defaultRenderWidth: React.PropTypes.number
+};
+
+const defaultProps = {
+  parentMayResize: false,
+  defaultRenderWidth: null
 };
 
 /**
  * Component for automatically setting a width prop to the DOM node of the first child
  */
 class AutoWidth extends React.Component {
-
   constructor(props) {
     super(props);
 
     this.state = {
-      width: 200 // arbitrary starting number
+      width: props.defaultRenderWidth
     };
 
     this.updateWidth = _.debounce(this.updateWidth.bind(this), 100);
@@ -31,23 +42,24 @@ class AutoWidth extends React.Component {
   }
 
   componentDidUpdate() {
-    // need this here to auto resize when window size changes
-    if (this.shouldUpdateWidth()) {
+    const { parentMayResize } = this.props;
+
+    // have to update width of the parent can cause a resize without a window resize
+    // e.g. something collapses or expands.
+    if (parentMayResize) {
       this.updateWidth();
     }
   }
 
-  // Returns true the dom node width is different than the stored state width
-  shouldUpdateWidth() {
-    const domWidth = this.getResizeDOMNode().offsetWidth;
-    return this.state.width !== domWidth;
-  }
-
   // Call set state to update the width so it starts an update of the child component
   updateWidth() {
-    this.setState({
-      width: this.getResizeDOMNode().offsetWidth
-    });
+    const { width } = this.state;
+    const domWidth = this.getResizeDOMNode().offsetWidth;
+    if (width !== domWidth) {
+      this.setState({
+        width: this.getResizeDOMNode().offsetWidth
+      });
+    }
   }
 
   getResizeDOMNode() {
@@ -55,16 +67,25 @@ class AutoWidth extends React.Component {
   }
 
   render() {
+    const { width } = this.state;
+
     if (React.Children.count(this.props.children) > 1) {
       console.warn('AutoWidth only works with a single child element.');
     }
 
     const child = this.props.children;
-    const newChild = child ? React.cloneElement(child, { width: this.state.width }) : null;
-    return <div className='auto-width'>{newChild}</div>;
+    let childToRender;
+
+    // if we have a child and a width is provided, render the child with the width as a prop
+    if (child && width != null) {
+      childToRender = React.cloneElement(child, { width: this.state.width });
+    }
+
+    return <div className='auto-width'>{childToRender}</div>;
   }
 }
 
 AutoWidth.propTypes = propTypes;
+AutoWidth.defaultProps = defaultProps;
 
 export default AutoWidth;


### PR DESCRIPTION
`parentMayResize` allows us to optimize for cases when there is no chance of the parent resizing outside of the window resizing by not calculating reflow on update.

`defaultRenderWidth` allows a smoother initial render by not rendering until a width is defined unless a default is provided.
