### PR TITLE
Fix styling for chiclets in multiselect to match filter summary

### DIFF
--- a/cancerbrowser/common/components/MultiSelectFilter/multi_select_filter.scss
+++ b/cancerbrowser/common/components/MultiSelectFilter/multi_select_filter.scss
@@ -4,7 +4,7 @@ $icon-width: 20px;
 .MultiSelectFilter {
 
   // style the chiclets
-  .Select-value {
+  .Select--multi .Select-value {
     position: relative;
     padding-right: $icon-width;
     color: #fff;


### PR DESCRIPTION
I suppose a minor update happened with react-select that broke the original styling set.

It currently looks like this:
![image](https://cloud.githubusercontent.com/assets/793847/16159175/350a3f3a-348f-11e6-9479-9a0b329cd4f1.png)

And it should have looked like (will look like this after the PR):
![image](https://cloud.githubusercontent.com/assets/793847/16159184/40f574c2-348f-11e6-8f5a-2b5bb7d37a55.png)
