### PR TITLE
Add google analytics integration

### DIFF
--- a/cancerbrowser/client/index.jsx
+++ b/cancerbrowser/client/index.jsx
@@ -23,7 +23,7 @@ if ( window.$REDUX_STATE ) {
   state = window.$REDUX_STATE;
 }
 
-const store = configureStore(state);
+const store = configureStore(browserHistory, state);
 const history = syncHistoryWithStore(browserHistory, store);
 
 // Watch routing in console

--- a/cancerbrowser/common/containers/CellLineBrowserPage/index.jsx
+++ b/cancerbrowser/common/containers/CellLineBrowserPage/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { ButtonGroup, Button } from 'react-bootstrap';
 import classNames from 'classnames';
-import { hashHistory } from 'react-router';
+import { replace } from 'react-router-redux';
 
 import FilterPanel from '../../components/FilterPanel';
 import FilterGroupSummary from '../../components/FilterGroupSummary';
@@ -87,8 +87,9 @@ class CellLineBrowserPage extends React.Component {
    * @param {Object} filters Filters to encode
    */
   updateFilterUrl(filters) {
-    const query = qs.stringify(filters, {encode: true});
-    hashHistory.replace({pathname: '/cell_lines', search: '?' + query });
+    const pathname = this.props.location.pathname;
+    const search = '?' + qs.stringify(filters, {encode: true});
+    this.props.dispatch(replace({pathname: pathname, search: search}));
   }
 
   /**

--- a/cancerbrowser/common/containers/DatasetBasePage/index.jsx
+++ b/cancerbrowser/common/containers/DatasetBasePage/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { hashHistory } from 'react-router';
+import { replace, push } from 'react-router-redux';
 import qs from 'qs';
 import _ from 'lodash';
 
@@ -158,9 +158,9 @@ class DatasetBasePage extends React.Component {
     const query = qs.stringify(allConfig, {encode: true});
     const newPath = {pathname: '/dataset/' + datasetId, search: '?' + query };
     if(mode === 'replace') {
-      hashHistory.replace(newPath);
+      this.props.dispatch(replace(newPath));
     } else {
-      hashHistory.push(newPath);
+      this.props.dispatch(push(newPath));
     }
   }
 

--- a/cancerbrowser/common/containers/DrugBrowserPage/index.jsx
+++ b/cancerbrowser/common/containers/DrugBrowserPage/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { ButtonGroup, Button } from 'react-bootstrap';
-import { hashHistory } from 'react-router';
+import { replace } from 'react-router-redux';
 import classNames from 'classnames';
 import qs from 'qs';
 
@@ -87,8 +87,9 @@ class DrugBrowserPage extends React.Component {
    * Store filter options in url
    */
   updateFilterUrl(newFilters) {
-    const query = qs.stringify(newFilters, {encode: true});
-    hashHistory.replace({pathname: '/drugs', search: '?' + query });
+    const pathname = this.props.location.pathname;
+    const search = '?' + qs.stringify(filters, {encode: true});
+    this.props.dispatch(replace({pathname: pathname, search: search}));
   }
 
   /**

--- a/cancerbrowser/common/utils/analytics_middleware.js
+++ b/cancerbrowser/common/utils/analytics_middleware.js
@@ -1,0 +1,25 @@
+import { LOCATION_CHANGE } from 'react-router-redux';
+import ga from 'ga-react-router'
+
+// Middleware to trigger async actions based on the route that is currently being loaded.
+export default store => next => action => {
+
+  if (
+    action.type === LOCATION_CHANGE
+  ) {
+    const prevState = store.getState();
+    const prevLocation = prevState.routing.locationBeforeTransitions;
+    const location = action.payload;
+    const prevPath = prevLocation ? prevLocation.pathname : null;
+    const path = location.pathname;
+    // Only send a pageview if the user actually navigated to a different page
+    // and didn't just change the query string via filter changes.
+    if (path !== prevPath) {
+      ga('set', 'page', path);
+      ga('send', 'pageview');
+    }
+  }
+
+  return next(action);
+};
+

--- a/cancerbrowser/common/utils/configureStore.js
+++ b/cancerbrowser/common/utils/configureStore.js
@@ -1,15 +1,19 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
+import { routerMiddleware } from 'react-router-redux';
 import combinedReducers from '../reducers';
+import analyticsMiddleware from './analytics_middleware';
 import { enableBatching } from 'redux-batched-actions';
 
-export default function configureStore(initialState = undefined) {
+export default function configureStore(browserHistory, initialState = undefined) {
   const store = createStore(
     enableBatching(combinedReducers),
     initialState,
     compose(
       applyMiddleware(
-        thunkMiddleware // lets us dispatch() functions
+        thunkMiddleware, // lets us dispatch() functions
+        routerMiddleware(browserHistory),
+        analyticsMiddleware
       ),
       (window.devToolsExtension) ? window.devToolsExtension() : f => f
     )

--- a/cancerbrowser/package.json
+++ b/cancerbrowser/package.json
@@ -63,6 +63,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "fs-extra": "^0.30.0",
+    "ga-react-router": "^2.1.1",
     "gh-pages-deploy": "^0.4.2",
     "html-webpack-plugin": "^2.17.0",
     "imports-loader": "^0.6.5",

--- a/cancerbrowser/webpack.config.build.js
+++ b/cancerbrowser/webpack.config.build.js
@@ -16,7 +16,8 @@ module.exports = [
       new webpack.DefinePlugin({
         'process.env':{
           'NODE_ENV': JSON.stringify('production')
-        }
+        },
+        GA_TRACKING_CODE: JSON.stringify('UA-28987198-3')
       }),
       new webpack.optimize.UglifyJsPlugin({
         include: /\.min\.js$/,


### PR DESCRIPTION
Location manipulation for filter settings is now done via redux actions instead
of direct calls to hashHistory. This is cleaner and also respects the overall
history configuration rather than forcing hash urls.

This only tracks pageviews; event tracking for other types of interactive
events will come later.
